### PR TITLE
Make the "sensitive" annotation a message rather than a raw bool.

### DIFF
--- a/udpa/annotations/sensitive.proto
+++ b/udpa/annotations/sensitive.proto
@@ -6,9 +6,13 @@ import "google/protobuf/descriptor.proto";
 
 extend google.protobuf.FieldOptions {
   // Magic number is the 28 most significant bits in the sha256sum of "udpa.annotations.sensitive".
-  // When set to true, `sensitive` indicates that this field contains sensitive data, such as
+  SensitiveAnnotation sensitive = 76569463;
+}
+
+message SensitiveAnnotation {
+  // When set to true, `redact` indicates that this field contains sensitive data, such as
   // personally identifiable information, passwords, or private keys, and should be redacted for
   // display by tools aware of this annotation. Note that that this has no effect on standard
   // Protobuf functions such as `TextFormat::PrintToString`.
-  bool sensitive = 76569463;
+  bool redact = 1;
 }


### PR DESCRIPTION
Signed-off-by: Dan Rosen <mergeconflict@google.com>