### PR TITLE
bazel: Add load statements for proto_library

### DIFF
--- a/bazel/api_build_system.bzl
+++ b/bazel/api_build_system.bzl
@@ -1,7 +1,8 @@
-load("@com_google_protobuf//:protobuf.bzl", _py_proto_library = "py_proto_library")
 load("@com_envoyproxy_protoc_gen_validate//bazel:pgv_proto_library.bzl", "pgv_cc_proto_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library", "go_proto_library")
+load("@com_google_protobuf//:protobuf.bzl", _py_proto_library = "py_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 _PY_PROTO_SUFFIX = "_py_proto"
 _CC_PROTO_SUFFIX = "_cc_proto"
@@ -83,7 +84,7 @@ def _udpa_cc_py_proto_library(
         linkstatic = 0,
         has_services = 0):
     relative_name = ":" + name
-    native.proto_library(
+    proto_library(
         name = name,
         srcs = srcs,
         deps = deps + _COMMON_PROTO_DEPS,

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -1,7 +1,7 @@
-load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 
 # go version for rules_go
 GO_VERSION = "1.12.8"

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -45,6 +45,10 @@ def udpa_api_dependencies():
         locations = REPOSITORY_LOCATIONS,
     )
     udpa_http_archive(
+        name = "rules_proto",
+        locations = REPOSITORY_LOCATIONS,
+    )
+    udpa_http_archive(
         name = "net_zlib",
         build_file_content = BUILD_ALL_CONTENT,
         locations = REPOSITORY_LOCATIONS,
@@ -54,6 +58,7 @@ def udpa_api_dependencies():
         build_file = "@com_google_protobuf//:six.BUILD",
         locations = REPOSITORY_LOCATIONS,
     )
+
     # Misc. rebinds
     native.bind(
         name = "six",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -39,6 +39,12 @@ REPOSITORY_LOCATIONS = dict(
         # 2019-07-17
         urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/a209b642c7687a8894c19b3dd40e43e6d3f38e83.tar.gz"],
     ),
+    rules_proto = dict(
+        sha256 = "73ebe9d15ba42401c785f9d0aeebccd73bd80bf6b8ac78f74996d31f2c0ad7a6",
+        strip_prefix = "rules_proto-2c0468366367d7ed97a1f702f9cd7155ab3f73c5",
+        # 2019-11-19
+        urls = ["https://github.com/bazelbuild/rules_proto/archive/2c0468366367d7ed97a1f702f9cd7155ab3f73c5.tar.gz"],
+    ),
     net_zlib = dict(
         sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
         strip_prefix = "zlib-1.2.11",


### PR DESCRIPTION
This prepares proto-gen-validate for `--incompatible_load_proto_rules_from_bzl`.
See https://github.com/bazelbuild/bazel/issues/8922

This commit was generated by `buildifier --lint=fix --warnings=native-proto -r .`.