### PR TITLE
urfc: process and template for uRFCs.

### DIFF
--- a/proposals/README.md
+++ b/proposals/README.md
@@ -1,0 +1,61 @@
+# UDPA RFCs (uRFCs)
+
+## Introduction
+
+This directory contains the design proposals for substantial feature changes for
+UDPA. The goal of this process is to:
+- Provide a reference for the UDPA transport protocol and data model standards.
+- Capture design history and tradeoffs as the UDPA APIs evolve.
+- Provide increased visibility to the community on upcoming changes and the
+  design considerations around them.
+- Provide ability to reason about larger “sets” of changes that are too big to
+  be covered either in an Issue or in a PR.
+- Establish a consistent process for structured participation by the community
+  on significant changes, especially those that impact multiple clients and servers.
+
+We have modeled the uRFC process on [gRPC
+RFCs](https://github.com/grpc/proposal).
+
+## Process
+
+1. Copy the template [URFC-TEMPLATE.md](URFC-TEMPLATE.md).
+1. Rename it to `$CategoryName##-$Summary.md`, e.g. `TP1-xds-transport-next.md`
+   (see category definitions below).
+1. Write up the RFC.
+1. Submit a Pull Request. The CNCF UDPA working group should be tagged with
+   `@cncf/udpa-wg` and an e-mail sent to `udpa-wg@lists.cncf.io` linking to the
+   PR. All discussion is expected to take place within the PR.
+1. An APPROVER will be assigned by one of this repository's maintainers.
+1. For at least a period of 10 business days (the minimum comment period),
+it is expected that the OWNER will respond to the comments and make updates
+to the RFC as new commits to the PR. Through the process, the discussion
+should take place within the PR to avoid splintering conversations. The OWNER is
+encouraged to solicit as much feedback on the proposal as possible during this
+period.
+1. If there is consensus as deemed by the APPROVER during the comment period,
+the APPROVER will mark the proposal as final and assign it a uRFC number.
+Once this is assigned (as part of the closure of discussion), the OWNER will
+update the state of the PR as final and submit the PR.
+
+## Proposal Categories
+
+The proposals shall be numbered in increasing order.
+
+- ``#TPn`` - Transport protocol.
+- ``#DMn`` - Data model.
+- ``#Pnn`` - Affects processes, such as the proposal process itself.
+
+## Proposal Status
+1. Every uncommitted proposal candidate starts off in the ``Draft`` state.
+1. After it accepted for review and posted to the group, it enters the
+``In Review`` state.
+1. Once it is approved for submission by the arbiter, it goes into the
+``Final`` state. Only minor changes are allowed (what qualifies as minor is
+left to the APPROVER).
+1. If a proposal needs to be revisited, it can be moved back to the ``Draft``
+or ``In Review`` state. This can happen if issues are discovered during
+implementation. At which point, the review process as described above must be
+followed.
+1. Once a proposal is ``Final`` and if it has been implemented by a xDS/UDPA client,
+it can be updated to a status of ``Implemented`` with the implementing
+xDS/UDPA client listed. (Listing versions is not required.)

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -19,8 +19,9 @@ RFCs](https://github.com/grpc/proposal).
 ## Process
 
 1. Copy the template [URFC-TEMPLATE.md](URFC-TEMPLATE.md).
-1. Rename it to `$CategoryName##-$Summary.md`, e.g. `TP1-xds-transport-next.md`
-   (see category definitions below).
+1. Rename it to `$CategoryName$uRfcId-$Summary.md`, e.g. `TP1-xds-transport-next.md`
+   (see category definitions below). The `$uRfcId` should be strictly higher
+   than any existing or under-review uRFC in `$CategoryName`.
 1. Write up the RFC.
 1. Submit a Pull Request. The CNCF UDPA working group should be tagged with
    `@cncf/udpa-wg` and an e-mail sent to `udpa-wg@lists.cncf.io` linking to the
@@ -33,9 +34,7 @@ should take place within the PR to avoid splintering conversations. The OWNER is
 encouraged to solicit as much feedback on the proposal as possible during this
 period.
 1. If there is consensus as deemed by the APPROVER during the comment period,
-the APPROVER will mark the proposal as final and assign it a uRFC number.
-Once this is assigned (as part of the closure of discussion), the OWNER will
-update the state of the PR as final and submit the PR.
+the APPROVER will merge the proposal pull request.
 
 ## Proposal Categories
 
@@ -46,16 +45,10 @@ The proposals shall be numbered in increasing order.
 - ``#Pnn`` - Affects processes, such as the proposal process itself.
 
 ## Proposal Status
-1. Every uncommitted proposal candidate starts off in the ``Draft`` state.
-1. After it accepted for review and posted to the group, it enters the
-``In Review`` state.
-1. Once it is approved for submission by the arbiter, it goes into the
-``Final`` state. Only minor changes are allowed (what qualifies as minor is
-left to the APPROVER).
-1. If a proposal needs to be revisited, it can be moved back to the ``Draft``
-or ``In Review`` state. This can happen if issues are discovered during
-implementation. At which point, the review process as described above must be
-followed.
-1. Once a proposal is ``Final`` and if it has been implemented by a xDS/UDPA client,
-it can be updated to a status of ``Implemented`` with the implementing
-xDS/UDPA client listed. (Listing versions is not required.)
+1. Every uncommitted proposal is effectively in draft status.
+1. Once committed, a proposal is in finalized status.
+1. If issues are discovered during implementation, revisions may be made by
+   following the review process.
+1. Once implemented by an xDS/UDPA client, this should be reflected in the
+   `Implemented in:` header field of the proposal. Listing versions is not
+   required.

--- a/proposals/URFC-TEMPLATE.md
+++ b/proposals/URFC-TEMPLATE.md
@@ -1,10 +1,9 @@
 Title
 ----
 * Author(s): [Author Name, Co-Author Name ...]
-* Approver: a11r
-* Status: {Draft, In Review, Final, Implemented}
+* Approver:
 * Implemented in: <xDS/UDPA client, ...>
-* Last updated: [Date]
+* Last updated: [YYYY-MM-DD]
 
 ## Abstract
 

--- a/proposals/URFC-TEMPLATE.md
+++ b/proposals/URFC-TEMPLATE.md
@@ -2,7 +2,7 @@ Title
 ----
 * Author(s): [Author Name, Co-Author Name ...]
 * Approver: a11r
-* Status: {Draft, In Review, Ready for Implementation, Implemented}
+* Status: {Draft, In Review, Final, Implemented}
 * Implemented in: <xDS/UDPA client, ...>
 * Last updated: [Date]
 

--- a/proposals/URFC-TEMPLATE.md
+++ b/proposals/URFC-TEMPLATE.md
@@ -1,0 +1,36 @@
+Title
+----
+* Author(s): [Author Name, Co-Author Name ...]
+* Approver: a11r
+* Status: {Draft, In Review, Ready for Implementation, Implemented}
+* Implemented in: <xDS/UDPA client, ...>
+* Last updated: [Date]
+
+## Abstract
+
+[A short summary of the proposal.]
+
+## Background
+
+[An introduction of the necessary background and the problem being solved by the proposed change.]
+
+
+### Related Proposals:
+* A list of proposals this proposal builds on or supersedes.
+
+## Proposal
+
+[A precise statement of the proposed change.]
+
+## Rationale
+
+[A discussion of alternate approaches and the trade offs, advantages, and disadvantages of the specified approach.]
+
+
+## Implementation
+
+[A description of the steps in the implementation, who will do them, and when.  If a particular client is going to get the implementation first, this section should list the proposed order.]
+
+## Open issues (if applicable)
+
+[A discussion of issues relating to this proposal for which the author does not  know the solution. This section may be omitted if there are none.]


### PR DESCRIPTION
In order to provide a permanent reference and process for evolving docs such as
https://docs.google.com/document/d/1m5_Q9LUlzvDdImP0jqh1lSTrLMldsApTQX6ibbd3i7c/edit
and amendments (e.g. https://github.com/cncf/udpa/issues/32), this patch
introduces a UDPA RFC (uRFC) process, modeled after gRPC RFCs
(https://github.com/grpc/proposal).

Fixes #33.

Signed-off-by: Harvey Tuch <htuch@google.com>