### PR TITLE
proposals: rename uRFC to xRFC.

### DIFF
--- a/proposals/README.md
+++ b/proposals/README.md
@@ -1,11 +1,11 @@
-# UDPA RFCs (uRFCs)
+# xDS RFCs (xRFCs)
 
 ## Introduction
 
 This directory contains the design proposals for substantial feature changes for
-UDPA. The goal of this process is to:
-- Provide a reference for the UDPA transport protocol and data model standards.
-- Capture design history and tradeoffs as the UDPA APIs evolve.
+xDS. The goal of this process is to:
+- Provide a reference for the xDS transport protocol and data model standards.
+- Capture design history and tradeoffs as the xDS APIs evolve.
 - Provide increased visibility to the community on upcoming changes and the
   design considerations around them.
 - Provide ability to reason about larger “sets” of changes that are too big to
@@ -13,18 +13,18 @@ UDPA. The goal of this process is to:
 - Establish a consistent process for structured participation by the community
   on significant changes, especially those that impact multiple clients and servers.
 
-We have modeled the uRFC process on [gRPC
+We have modeled the xRFC process on [gRPC
 RFCs](https://github.com/grpc/proposal).
 
 ## Process
 
-1. Copy the template [URFC-TEMPLATE.md](URFC-TEMPLATE.md).
-1. Rename it to `$CategoryName$uRfcId-$Summary.md`, e.g. `TP1-xds-transport-next.md`
-   (see category definitions below). The `$uRfcId` should be strictly higher
-   than any existing or under-review uRFC in `$CategoryName`.
+1. Copy the template [XRFC-TEMPLATE.md](XRFC-TEMPLATE.md).
+1. Rename it to `$CategoryName$xRfcId-$Summary.md`, e.g. `TP1-xds-transport-next.md`
+   (see category definitions below). The `$xRfcId` should be strictly higher
+   than any existing or under-review xRFC in `$CategoryName`.
 1. Write up the RFC.
-1. Submit a Pull Request. The CNCF UDPA working group should be tagged with
-   `@cncf/udpa-wg` and an e-mail sent to `udpa-wg@lists.cncf.io` linking to the
+1. Submit a Pull Request. The CNCF xDS working group should be tagged with
+   `@cncf/xds-wg` and an e-mail sent to `xds-wg@lists.cncf.io` linking to the
    PR. All discussion is expected to take place within the PR.
 1. An APPROVER will be assigned by one of this repository's maintainers.
 1. For at least a period of 10 business days (the minimum comment period),
@@ -49,6 +49,6 @@ The proposals shall be numbered in increasing order.
 1. Once committed, a proposal is in finalized status.
 1. If issues are discovered during implementation, revisions may be made by
    following the review process.
-1. Once implemented by an xDS/UDPA client, this should be reflected in the
+1. Once implemented by an xDS client, this should be reflected in the
    `Implemented in:` header field of the proposal. Listing versions is not
    required.

--- a/proposals/XRFC-TEMPLATE.md
+++ b/proposals/XRFC-TEMPLATE.md
@@ -2,7 +2,7 @@ Title
 ----
 * Author(s): [Author Name, Co-Author Name ...]
 * Approver:
-* Implemented in: <xDS/UDPA client, ...>
+* Implemented in: <xDS client, ...>
 * Last updated: [YYYY-MM-DD]
 
 ## Abstract


### PR DESCRIPTION
As per the other renames happening in the CNCF UDPA-WG -> XDS-WG update.

Signed-off-by: Harvey Tuch <htuch@google.com>