### PR TITLE
protos: Cleanup unused imports

### DIFF
--- a/udpa/annotations/security.proto
+++ b/udpa/annotations/security.proto
@@ -4,10 +4,7 @@ package udpa.annotations;
 
 import "udpa/annotations/status.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/descriptor.proto";
-
-import "validate/validate.proto";
 
 // All annotations in this file are experimental and subject to change. Their
 // only consumer today is the Envoy APIs and SecuritAnnotationValidator protoc


### PR DESCRIPTION
cleaning up redundant proto imports

(not entirely clear if these are redundant, but they trigger a lot of warnings)